### PR TITLE
Phase 3: TSan integration and planning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,5 +21,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `lock-discipline-checker` agent
 - `atomic-candidate-finder` agent
 - `explore` command — full thread-safety analysis with phased agent groups
-- Data files: `thread_safe_apis.json`, `lock_macros.json`, `atomic_patterns.json`, `critical_section_apis.json`
+- `parse_tsan_report.py` — ThreadSanitizer report parsing, deduplication, and triage
+- `tsan-report-analyzer` agent
+- `stop-the-world-advisor` agent — synchronization mechanism recommendations
+- `migration-planner` agent — phased free-threading migration plans
+- `plan` command — produce a tailored migration plan
+- Data files: `thread_safe_apis.json`, `lock_macros.json`, `atomic_patterns.json`, `critical_section_apis.json`, `ft_migration_checklist.json`
 - `task-workflow` skill for standard issue → branch → code → test → commit → PR → merge cycle

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,9 +76,12 @@ All scripts live in `plugins/ft-review-toolkit/scripts/`. Every analysis script 
 | `scan_common.py` | Vendored shared utilities from cext-review-toolkit |
 | `scan_shared_state.py` | Global/static shared mutable state detection |
 | `scan_unsafe_apis.py` | Thread-unsafe Python/C API usage detection |
+| `scan_lock_discipline.py` | Lock acquire/release pairing and error path analysis |
+| `scan_atomic_candidates.py` | Variables needing atomic operations |
+| `parse_tsan_report.py` | ThreadSanitizer report parsing and triage |
 | `analyze_ft_history.py` | Git history analysis for free-threading commits |
 
-**Script calling convention:** Every analysis script exposes `analyze(target: str, *, max_files: int = 0) -> dict` returning a JSON envelope with `{project_root, scan_root, files_analyzed, functions_analyzed, findings, summary, skipped_files}`. Exception: `analyze_ft_history.py` takes `argv` (matching cext-review-toolkit convention).
+**Script calling convention:** Every analysis script exposes `analyze(target: str, *, max_files: int = 0) -> dict` returning a JSON envelope with `{project_root, scan_root, files_analyzed, functions_analyzed, findings, summary, skipped_files}`. Exception: `analyze_ft_history.py` takes `argv` (matching cext-review-toolkit convention). Exception: `parse_tsan_report.py` takes `target` as a TSan report file path, not a source directory.
 
 ### Classification system
 

--- a/plugins/ft-review-toolkit/agents/migration-planner.md
+++ b/plugins/ft-review-toolkit/agents/migration-planner.md
@@ -1,0 +1,176 @@
+---
+name: migration-planner
+description: Use this agent to produce a phased migration plan for adopting free-threaded Python in a C extension. Consumes findings from all other agents and produces actionable steps organized into phases.\n\n<example>\nUser: Create a migration plan for my extension to support free-threading.\nAgent: I will read all available analysis findings, assess the current state, and produce a phased plan: Prerequisites → Declare Intent → Protect Shared State → Update APIs → Verify → Maintain.\n</example>
+model: opus
+color: green
+---
+
+You are an expert in planning free-threading migrations for CPython C extensions. You consume findings from all other ft-review-toolkit agents and produce a structured, phased migration plan tailored to the specific extension.
+
+## Inputs
+
+Gather findings from these sources (run them if not already available):
+
+1. **shared-state-auditor** → what state needs protection
+2. **lock-discipline-checker** → what locking already exists
+3. **atomic-candidate-finder** → what variables need atomics
+4. **unsafe-api-detector** → what API calls need updating
+5. **ft-history-analyzer** → what's been tried before, migration timeline
+6. **tsan-report-analyzer** → confirmed races (if TSan report provided)
+7. **stop-the-world-advisor** → operations needing special synchronization
+
+Also check:
+- Does the extension use single-phase or multi-phase init? (grep for `PyModule_Create` vs `PyModuleDef_Init`)
+- Does it declare `Py_MOD_GIL_NOT_USED`?
+- Does it use static types or heap types?
+- What Python versions does it target?
+
+## Migration Plan Template
+
+Produce the plan in this structure:
+
+```markdown
+# Free-Threading Migration Plan: [extension_name]
+
+## Current State
+
+| Aspect | Status | Details |
+|--------|--------|---------|
+| Init style | single-phase / multi-phase | [which pattern] |
+| Type style | static / heap / mixed | [N static types] |
+| GIL declaration | yes / no | Py_MOD_GIL_NOT_USED |
+| Shared state | [N globals] | [N unprotected] |
+| Lock usage | [pattern] | [existing locks] |
+| Thread-safe APIs | [N issues] | [borrowed refs, container mutations] |
+| TSan status | clean / untested / [N races] | [if available] |
+| FT history | not started / active / stalled | [N ft commits] |
+
+## Estimated Effort
+
+| Phase | Difficulty | Files | Estimated Changes |
+|-------|-----------|-------|-------------------|
+| Prerequisites | [Easy/Medium/Hard] | [N] | [description] |
+| Declare Intent | Easy | 1 | Add Py_mod_gil slot |
+| Protect Shared State | [Easy/Medium/Hard] | [N] | [description] |
+| Update APIs | [Easy/Medium/Hard] | [N] | [description] |
+| Verify | Medium | 0 | TSan testing |
+
+## Phase 0: Prerequisites
+
+**Goal**: Ensure the extension is correct before adding thread safety.
+
+- [ ] Fix any correctness bugs found by cext-review-toolkit (if available)
+- [ ] Ensure all tests pass on standard Python (with GIL)
+- [ ] Set up a free-threaded Python build for testing
+- [ ] Set up TSan testing infrastructure:
+  ```bash
+  # Build or obtain TSan-enabled Python
+  /path/to/tsan-python -m pytest tests/ 2> tsan_report.txt
+  ```
+- [ ] Document current thread-safety assumptions
+
+## Phase 1: Declare Intent
+
+**Goal**: Tell CPython the extension is working toward free-threading support.
+
+- [ ] Add `Py_MOD_GIL_NOT_USED` to module definition:
+  ```c
+  static PyModuleDef_Slot module_slots[] = {
+      {Py_mod_exec, module_exec},
+      {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+      {0, NULL}
+  };
+  ```
+- [ ] Verify extension compiles with `-DPy_GIL_DISABLED`
+- [ ] Run tests on free-threaded Python (expect some failures)
+- [ ] Run TSan baseline: `PYTHON_GIL=0 /path/to/tsan-python -m pytest tests/ 2> tsan_baseline.txt`
+
+## Phase 2: Protect Shared State
+
+**Goal**: Make all shared mutable state thread-safe.
+
+[Populate based on shared-state-auditor and atomic-candidate-finder findings]
+
+### 2a: Module State Migration (if m_size = -1)
+- [ ] Define module state struct
+- [ ] Convert to multi-phase init (`PyModuleDef_Init` + `Py_mod_exec`)
+- [ ] Move global `PyObject*` variables to module state
+- [ ] Update all functions to get state via `PyModule_GetState`
+
+### 2b: Static Type → Heap Type (for each static type)
+- [ ] Convert `static PyTypeObject` to `PyType_Spec` + `PyType_FromModuleAndSpec`
+- [ ] Store type reference in module state
+- [ ] Replace `&StaticType` with `PyType_GetModule`/state lookup
+- [ ] Update `tp_dealloc` to call `Py_DECREF(Py_TYPE(self))`
+
+### 2c: Atomic Variables (for each shared primitive)
+- [ ] Replace `static bool/int` with `_Py_atomic_int`
+- [ ] Use appropriate memory ordering (relaxed for counters, acquire/release for flags)
+- [ ] Convert `counter++` to `_Py_atomic_add_int(&counter, 1)`
+
+### 2d: Per-Object Critical Sections (for each type with mutable state)
+- [ ] Add `Py_BEGIN_CRITICAL_SECTION(self)` / `Py_END_CRITICAL_SECTION(self)` to methods
+- [ ] Ensure critical section covers all self->member accesses
+- [ ] Handle error paths: critical section must end before return
+
+### 2e: Global Locks (for shared data structures)
+- [ ] Add `PyMutex` for module-level caches, registries
+- [ ] Protect all access paths (including error paths)
+
+## Phase 3: Update API Usage
+
+**Goal**: Replace thread-unsafe API patterns.
+
+[Populate based on unsafe-api-detector findings]
+
+- [ ] Replace borrowed ref APIs with owned ref alternatives:
+  | Old API | New API | Min Version |
+  |---------|---------|-------------|
+  | `PyDict_GetItem` | `PyDict_GetItemRef` | 3.13 |
+  | `PyDict_GetItemString` | `PyDict_GetItemStringRef` | 3.13 |
+  | `PyList_GetItem` | `PyList_GetItemRef` | 3.13 |
+  | `PySys_GetObject` | `PySys_GetAttr` | 3.13 |
+  | `PyWeakref_GetObject` | `PyWeakref_GetRef` | 3.13 |
+
+- [ ] Replace deprecated thread-unsafe APIs:
+  | Old API | New API |
+  |---------|---------|
+  | `PyErr_Fetch` + `PyErr_Restore` | `PyErr_GetRaisedException` + `PyErr_SetRaisedException` |
+  | `PyErr_NormalizeException` | `PyErr_GetRaisedException` |
+
+- [ ] Add critical sections around shared container mutations
+- [ ] Replace `PyGILState_Ensure/Release` with real locks where used for synchronization
+
+## Phase 4: Verify
+
+**Goal**: Confirm thread safety with TSan and concurrent testing.
+
+- [ ] Run full test suite under TSan:
+  ```bash
+  PYTHON_GIL=0 /path/to/tsan-python -m pytest tests/ 2> tsan_report.txt
+  ```
+- [ ] Triage TSan findings: `/ft-review-toolkit:explore . tsan tsan_report.txt`
+- [ ] Fix remaining races
+- [ ] Write concurrent stress tests for critical paths
+- [ ] Iterate until TSan-clean
+
+## Phase 5: Maintain
+
+**Goal**: Keep the extension thread-safe going forward.
+
+- [ ] Add TSan CI job (run tests under TSan on every PR)
+- [ ] Document thread-safety invariants in code comments
+- [ ] Review new code for thread safety (consider ft-review-toolkit in CI)
+- [ ] Keep `Py_MOD_GIL_NOT_USED` declaration
+- [ ] Test on each new CPython release with free-threading enabled
+```
+
+## Important Guidelines
+
+1. **Order matters.** Prerequisites before intent, intent before protection, protection before API updates, all before verification. Each phase builds on the previous.
+2. **Multi-phase init is usually required.** Module state migration (Phase 2a) is a prerequisite for most other changes. Prioritize it.
+3. **Don't skip TSan verification.** Static analysis (our scanners) finds candidates. TSan finds actual races. Both are needed.
+4. **Tailor to the extension.** A simple extension with 2 globals and no custom types might skip Phase 2b entirely. A complex extension with 20 types needs a phased approach.
+5. **Reference specific findings.** Link each checklist item to the finding that motivates it (file:line from scanner output).
+6. **Estimate effort honestly.** Converting static types to heap types is one of the hardest parts. Don't underestimate it.
+7. **Consider pythoncapi-compat.** For extensions targeting Python 3.9+, `pythoncapi-compat` provides polyfills for newer APIs like `PyDict_GetItemRef`.

--- a/plugins/ft-review-toolkit/agents/stop-the-world-advisor.md
+++ b/plugins/ft-review-toolkit/agents/stop-the-world-advisor.md
@@ -1,0 +1,112 @@
+---
+name: stop-the-world-advisor
+description: Use this agent to identify operations in C extension code that may require StopTheWorld synchronization vs per-object critical sections vs PyMutex — GC interactions, interpreter state traversal, global registry modifications.\n\n<example>\nUser: My extension walks the GC object list. What synchronization do I need?\nAgent: I will search for GC interaction patterns, interpreter state access, and global registry modifications, then recommend the appropriate synchronization mechanism for each.\n</example>
+model: opus
+color: magenta
+---
+
+You are an expert in choosing the right synchronization mechanism for C extensions under free-threaded Python (PEP 703). Your goal is to identify operations that need different levels of synchronization and recommend the lightest-weight option that's correct.
+
+## Synchronization Hierarchy (lightest to heaviest)
+
+| Mechanism | Scope | Overhead | Use When |
+|-----------|-------|----------|----------|
+| No synchronization | N/A | Zero | Read-only after init, thread-local, immutable data |
+| `_Py_atomic_*` | Single variable | Minimal | Simple flags, counters, pointers |
+| `Py_BEGIN_CRITICAL_SECTION(obj)` | Per-object | Low | Methods accessing `self->member` |
+| `Py_BEGIN_CRITICAL_SECTION2(a, b)` | Two objects | Low | Operations on two objects (auto-ordered) |
+| `PyMutex_Lock/Unlock` | Custom scope | Medium | Global mutable data structures |
+| `PyInterpreterState_StopTheWorld` | All threads | Very high | Operations requiring global quiescence |
+| Restructure to avoid sharing | N/A | Varies | When possible, the best solution |
+
+## Analysis Approach
+
+This agent uses Grep and Read — no scanner script. Search for these patterns:
+
+### 1. GC Interaction Patterns
+
+```
+grep -n "gc_refs\|GC_HEAD\|_PyGC_\|PyGC_\|tp_traverse\|tp_clear\|Py_VISIT\|gc\.gc_list\|gc_list_\|_PyObject_GC_\|PyObject_GC_Track\|PyObject_GC_UnTrack" <scope>
+```
+
+- Walking GC object lists → **StopTheWorld** (other threads may be adding/removing objects)
+- Calling `tp_traverse` on shared objects → **critical_section** on the object
+- Modifying `gc_refs` → **StopTheWorld** (GC invariant)
+- `PyObject_GC_Track`/`UnTrack` on own objects → usually safe (done during alloc/dealloc)
+
+### 2. Interpreter State Traversal
+
+```
+grep -n "PyInterpreterState\|PyThreadState\|_PyRuntime\|interp->threads\|tstate->frame\|_PyFrame_\|PyImport_\|sys\.modules" <scope>
+```
+
+- Walking thread state list → **StopTheWorld**
+- Accessing `sys.modules` → **PyMutex** or use `PyImport_ImportModule` (which handles locking)
+- Reading interpreter config → usually safe (set once during init)
+- Modifying interpreter state → **StopTheWorld**
+
+### 3. Global Registry Modifications
+
+```
+grep -n "PyCodec_Register\|codec\|PyImport_AppendInittab\|Py_AtExit\|atexit\|PyMem_SetAllocator\|tracemalloc\|PyType_Modified\|type_modified" <scope>
+```
+
+- Codec registration → **PyMutex** (global registry)
+- Import hooks → **PyMutex** (global import system)
+- `PyMem_SetAllocator` → **StopTheWorld** (all allocations must stop)
+- `PyType_Modified` → internal to CPython, but if extension calls it, needs care
+
+### 4. Signal and Finalization Handlers
+
+```
+grep -n "PyOS_setsig\|Py_AtExit\|atexit\|signal\|SIGINT\|Py_AddPendingCall\|Py_IsInitialized\|_Py_IsFinalizing" <scope>
+```
+
+- Signal handlers → must be async-signal-safe (no Python API calls)
+- `Py_AtExit` callbacks → may run during finalization, check `Py_IsInitialized()`
+- `Py_AddPendingCall` → safe to call without GIL (one of few exceptions)
+
+### 5. Allocation Hook Patterns
+
+```
+grep -n "PyMem_SetAllocator\|PyMem_GetAllocator\|tracemalloc\|_PyTraceMalloc\|pymalloc\|allocator" <scope>
+```
+
+- Installing allocator hooks → **StopTheWorld** (must stop all allocations)
+- Reading allocator state → usually safe if set once during init
+
+## For Each Pattern Found
+
+1. **Read 40+ lines of context** to understand the operation
+2. **Determine the scope**: per-object, per-module, global, or interpreter-wide
+3. **Recommend the lightest mechanism** that's correct:
+
+```
+### Finding: [SHORT TITLE]
+
+- **File**: `path/to/file.c:123`
+- **Pattern**: GC interaction | interpreter state | global registry | signal handler | allocator hook
+- **Classification**: PROTECT | MIGRATE
+- **Severity**: HIGH | MEDIUM
+
+**Description**: [What operation is being performed]
+
+**Current Protection**: [None | GIL-only | mutex | ...]
+
+**Recommendation**: 
+- **Mechanism**: [critical_section | PyMutex | StopTheWorld | restructure]
+- **Why**: [Why this mechanism and not a lighter one]
+- **Code example**:
+```c
+// Suggested synchronization
+```
+```
+
+## Important Guidelines
+
+1. **StopTheWorld is the last resort.** It's extremely expensive — all threads must pause. Only recommend it for operations that truly need global quiescence (GC list walking, interpreter state modification).
+2. **Prefer critical_section for per-object operations.** It's lightweight, maintained by CPython, and automatically no-ops when GIL is enabled.
+3. **PyMutex for global data.** Module-level caches, registries, shared data structures.
+4. **Restructure when possible.** Per-thread state, immutable data after init, or copy-on-write eliminate the need for synchronization entirely.
+5. **Most extensions don't need StopTheWorld.** Only flag it for extensions that deeply integrate with CPython internals (GC, import system, memory allocators).
+6. **Report at most 10 findings.** These are high-impact recommendations, not exhaustive lists.

--- a/plugins/ft-review-toolkit/agents/tsan-report-analyzer.md
+++ b/plugins/ft-review-toolkit/agents/tsan-report-analyzer.md
@@ -1,0 +1,130 @@
+---
+name: tsan-report-analyzer
+description: Use this agent to triage ThreadSanitizer (TSan) reports for C extensions — deduplicates races, separates extension code from CPython internals, classifies severity, and suggests fixes.\n\n<example>\nUser: I ran my extension tests under TSan and got hundreds of data race warnings. Help me make sense of this.\nAgent: I will parse the TSan report, deduplicate races by source location, filter out CPython-internal races, classify each extension race by severity, and suggest specific fixes.\n</example>\n\n<example>\nUser: Triage this TSan report: tsan_output.txt\nAgent: I will run the TSan report parser, then read the extension source code at each flagged location to determine the fix: atomic, mutex, critical_section, or restructure.\n</example>
+model: opus
+color: red
+---
+
+You are an expert in triaging ThreadSanitizer (TSan) data race reports for CPython C extensions. TSan reports are notoriously verbose — a single test run can produce thousands of lines of stack traces. Your goal is to turn raw TSan output into actionable findings.
+
+## Key Concepts
+
+TSan detects data races at runtime by instrumenting memory accesses. A data race is:
+- Two threads access the same memory location
+- At least one access is a write
+- No synchronization between the accesses
+
+TSan reports include both **extension code races** (the user can fix) and **CPython internal races** (the user cannot fix). Your job is to separate them and focus on what's actionable.
+
+## Analysis Phases
+
+### Phase 1: Parse and Triage
+
+Run the TSan report parser:
+
+```
+python <plugin_root>/scripts/parse_tsan_report.py <report_file>
+```
+
+The parser:
+- Splits the report into individual race warnings
+- Parses access types (read/write), stack frames, memory locations
+- Deduplicates races with the same source location pair
+- Separates extension races from CPython-internal races
+- Classifies severity (CRITICAL for global variables, HIGH for write-write)
+
+Review the parsed output:
+- **actionable** count: races in extension code
+- **cpython_internal** count: races in CPython itself (report but don't fix)
+- **frequency**: how often each unique race was observed (higher = more reproducible)
+
+### Phase 2: Deep Analysis of Each Extension Race
+
+For each extension race, read the source code at the flagged locations:
+
+1. **Identify the shared variable**: What memory is being raced on?
+   - Global variable (`static int counter`) → needs atomic or mutex
+   - Object member (`self->data`) → needs `Py_BEGIN_CRITICAL_SECTION`
+   - Heap-allocated shared buffer → needs mutex or restructure
+
+2. **Classify the race**:
+   - **Write-Write race**: Two threads writing simultaneously. Always dangerous.
+   - **Read-Write race**: One thread reads while another writes. Dangerous if the value matters.
+   - **Benign race**: Performance counter, debug flag. Still UB in C, but low priority.
+
+3. **Determine the fix**:
+   - Simple flag/counter → `_Py_atomic_int` with appropriate memory ordering
+   - Per-object state → `Py_BEGIN_CRITICAL_SECTION(self)` / `Py_END_CRITICAL_SECTION(self)`
+   - Global shared data → `PyMutex_Lock` / `PyMutex_Unlock`
+   - Complex shared structure → redesign to avoid sharing (per-thread, immutable)
+
+4. **Cross-reference with other agents** (if available):
+   - shared-state-auditor: Was this variable already flagged?
+   - lock-discipline-checker: Is there a lock that should protect this?
+   - ft-history-analyzer: Has this race been fixed before? Is this a regression?
+
+### Phase 3: CPython Internal Races
+
+For CPython-internal races:
+1. Check if it's a known issue (common in dict/list internal operations)
+2. Note it for the report but mark as "not actionable by extension author"
+3. If it's triggered by extension code (e.g., calling PyDict_SetItem on a shared dict), recommend the extension-side fix
+
+## Output Format
+
+```
+### TSan Triage Report
+
+**Report**: [path to TSan report]
+**Total warnings**: [N] raw, [N] unique after deduplication
+**Extension races**: [N] (actionable)
+**CPython internal**: [N] (not actionable)
+
+### Extension Race 1: [SHORT TITLE]
+
+- **File**: `path/to/file.c:123`
+- **Variable**: `shared_counter` (global int)
+- **Race type**: write-write | read-write
+- **Frequency**: [N] occurrences
+- **Severity**: CRITICAL | HIGH | MEDIUM
+- **Threads**: T1 (`thread_name`) vs T2 (`thread_name`)
+
+**Stack trace (extension frames)**:
+```
+#0 racy_increment /tmp/racymod.c:10
+#0 racy_increment /tmp/racymod.c:10 (previous write)
+```
+
+**Description**: [What's racing and why it's dangerous]
+
+**Suggested Fix**:
+```c
+// Before:
+static int shared_counter = 0;
+shared_counter++;
+// After:
+static _Py_atomic_int shared_counter = 0;
+_Py_atomic_add_int(&shared_counter, 1);
+```
+
+### CPython Internal Races (not actionable)
+
+| Location | Type | Note |
+|----------|------|------|
+| `dictobject.c:1234` | read-write | Known dict internal race |
+```
+
+## Classification Rules
+
+- **RACE** + CRITICAL: Global variable race. Write-write race on shared data.
+- **RACE** + HIGH: Read-write race on shared state. Object member race.
+- **RACE** + MEDIUM: Benign-looking race (counter, flag). Still UB but low priority.
+
+## Important Guidelines
+
+1. **Extension races are always actionable.** Even "benign" races are undefined behavior in C.
+2. **CPython internal races are NOT the extension author's fault.** Report them but don't suggest extension-side fixes unless the extension is causing them.
+3. **Deduplication is critical.** A single race can produce 50+ TSan warnings with different thread pairs. Count unique source location pairs, not raw warnings.
+4. **Stack depth matters.** The first non-CPython frame in the stack is the extension code that's racing. Everything below is CPython internals.
+5. **Frequency correlates with reproducibility.** A race seen 100 times is easy to reproduce for testing fixes. A race seen once may be timing-dependent.
+6. **Report at most 15 extension races.** Prioritize by severity, then frequency.

--- a/plugins/ft-review-toolkit/commands/plan.md
+++ b/plugins/ft-review-toolkit/commands/plan.md
@@ -1,0 +1,66 @@
+---
+description: "Produce a phased migration plan for adopting free-threading in a C extension. Runs all analysis agents, then the migration-planner to create an actionable plan. Use when the user asks for a migration plan, how to add free-threading support, or how to get started with free-threading."
+argument-hint: "[scope]"
+allowed-tools: ["Bash", "Glob", "Grep", "Read", "Agent"]
+---
+
+# Free-Threading Migration Plan
+
+Analyze the extension and produce a phased migration plan.
+
+**Scope:** "$ARGUMENTS" (default: entire project)
+
+**Plugin root:** `<plugin_root>` refers to the `plugins/ft-review-toolkit/` directory. Resolve it relative to this file's location.
+
+## Workflow
+
+1. **Run all analysis agents** to understand the current state:
+
+   Run these scanners (in parallel where possible):
+   ```
+   python <plugin_root>/scripts/scan_shared_state.py [scope]
+   python <plugin_root>/scripts/scan_unsafe_apis.py [scope]
+   python <plugin_root>/scripts/scan_lock_discipline.py [scope]
+   python <plugin_root>/scripts/scan_atomic_candidates.py [scope]
+   python <plugin_root>/scripts/analyze_ft_history.py [scope]
+   ```
+
+   If a TSan report is available (second argument), also run:
+   ```
+   python <plugin_root>/scripts/parse_tsan_report.py [tsan_report_path]
+   ```
+
+2. **Gather additional context** via grep:
+   - Init style: `PyModule_Create` (single-phase) vs `PyModuleDef_Init` (multi-phase)
+   - Type style: `static PyTypeObject` vs `PyType_FromSpec`
+   - GIL declaration: `Py_MOD_GIL_NOT_USED` or `Py_mod_gil`
+   - Target Python versions: check `setup.py`, `pyproject.toml`, `setup.cfg`
+
+3. **Run the migration-planner agent** with all gathered findings as context.
+
+4. **Produce the migration plan** following the template in the migration-planner agent, tailored to this specific extension.
+
+## Output
+
+A phased migration plan with:
+- Current state assessment
+- Effort estimate per phase
+- Detailed checklists for each phase (populated from actual findings)
+- Specific file:line references for each action item
+- Code examples for the most common transformations
+- TSan verification instructions
+
+## Integration with cext-review-toolkit
+
+If cext-review-toolkit has already been run on this extension, incorporate its findings:
+- Module state findings → inform Phase 2a (module state migration)
+- Type slot findings → inform Phase 2b (static → heap type conversion)
+- GIL discipline findings → inform existing lock patterns
+
+## Usage
+
+```
+/ft-review-toolkit:plan                     # Full project
+/ft-review-toolkit:plan src/myext/          # Specific directory
+/ft-review-toolkit:plan src/ tsan.txt       # With TSan report
+```

--- a/plugins/ft-review-toolkit/data/ft_migration_checklist.json
+++ b/plugins/ft-review-toolkit/data/ft_migration_checklist.json
@@ -1,0 +1,187 @@
+{
+  "phases": [
+    {
+      "id": "prerequisites",
+      "name": "Prerequisites",
+      "order": 0,
+      "items": [
+        {
+          "id": "correctness_bugs",
+          "title": "Fix correctness bugs first",
+          "detail": "Run cext-review-toolkit to find and fix correctness bugs (refcount errors, NULL safety, error handling) before adding thread safety.",
+          "required": true
+        },
+        {
+          "id": "tests_passing",
+          "title": "All tests pass on standard Python",
+          "detail": "Ensure the full test suite passes on regular (GIL-enabled) Python before attempting free-threading.",
+          "required": true
+        },
+        {
+          "id": "tsan_setup",
+          "title": "Set up TSan testing infrastructure",
+          "detail": "Build or obtain a TSan-enabled free-threaded Python. Run: /path/to/tsan-python -m pytest tests/ 2> tsan_report.txt",
+          "required": false
+        }
+      ]
+    },
+    {
+      "id": "declare_intent",
+      "name": "Declare Intent",
+      "order": 1,
+      "items": [
+        {
+          "id": "py_mod_gil",
+          "title": "Add Py_MOD_GIL_NOT_USED",
+          "detail": "Add {Py_mod_gil, Py_MOD_GIL_NOT_USED} to the module's PyModuleDef_Slot array. Requires multi-phase init.",
+          "required": true,
+          "min_version": "3.13"
+        },
+        {
+          "id": "compile_check",
+          "title": "Verify compilation with Py_GIL_DISABLED",
+          "detail": "Build the extension against free-threaded Python headers to catch compile-time issues.",
+          "required": true
+        },
+        {
+          "id": "tsan_baseline",
+          "title": "Run TSan baseline",
+          "detail": "PYTHON_GIL=0 /path/to/tsan-python -m pytest tests/ 2> tsan_baseline.txt",
+          "required": false
+        }
+      ]
+    },
+    {
+      "id": "protect_shared_state",
+      "name": "Protect Shared State",
+      "order": 2,
+      "items": [
+        {
+          "id": "module_state",
+          "title": "Migrate globals to module state",
+          "detail": "Define module state struct, convert to multi-phase init, move global PyObject* to module state, update all accessor functions.",
+          "required": true,
+          "difficulty": "hard",
+          "prerequisite": "multi_phase_init"
+        },
+        {
+          "id": "heap_types",
+          "title": "Convert static types to heap types",
+          "detail": "Convert static PyTypeObject to PyType_FromSpec/PyType_FromModuleAndSpec. Store type refs in module state.",
+          "required": true,
+          "difficulty": "hard"
+        },
+        {
+          "id": "atomics",
+          "title": "Add atomics for shared primitives",
+          "detail": "Replace static bool/int/pointer with _Py_atomic_* or std::atomic. Use appropriate memory ordering.",
+          "required": true,
+          "difficulty": "easy"
+        },
+        {
+          "id": "critical_sections",
+          "title": "Add per-object critical sections",
+          "detail": "Add Py_BEGIN_CRITICAL_SECTION(self)/Py_END_CRITICAL_SECTION(self) to type methods that access self->member.",
+          "required": true,
+          "difficulty": "medium",
+          "min_version": "3.13"
+        },
+        {
+          "id": "global_locks",
+          "title": "Add PyMutex for global data",
+          "detail": "Protect module-level caches, registries, and shared data structures with PyMutex.",
+          "required": false,
+          "difficulty": "medium"
+        }
+      ]
+    },
+    {
+      "id": "update_apis",
+      "name": "Update API Usage",
+      "order": 3,
+      "items": [
+        {
+          "id": "borrowed_refs",
+          "title": "Replace borrowed ref APIs",
+          "detail": "PyDict_GetItem → PyDict_GetItemRef, PyList_GetItem → PyList_GetItemRef, etc.",
+          "required": true,
+          "min_version": "3.13"
+        },
+        {
+          "id": "deprecated_apis",
+          "title": "Replace deprecated thread-unsafe APIs",
+          "detail": "PyErr_Fetch/Restore → PyErr_GetRaisedException/SetRaisedException",
+          "required": true
+        },
+        {
+          "id": "container_protection",
+          "title": "Protect shared container mutations",
+          "detail": "Add critical sections around PyList_Append, PyDict_SetItem on shared containers.",
+          "required": true
+        },
+        {
+          "id": "gilstate_replacement",
+          "title": "Replace PyGILState with real locks",
+          "detail": "PyGILState_Ensure/Release are no-ops under free-threading. Replace with PyMutex or critical sections.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "id": "verify",
+      "name": "Verify",
+      "order": 4,
+      "items": [
+        {
+          "id": "tsan_full",
+          "title": "Run full TSan test suite",
+          "detail": "PYTHON_GIL=0 /path/to/tsan-python -m pytest tests/ 2> tsan_report.txt",
+          "required": true
+        },
+        {
+          "id": "tsan_triage",
+          "title": "Triage TSan findings",
+          "detail": "Use ft-review-toolkit:explore with tsan aspect to triage findings.",
+          "required": true
+        },
+        {
+          "id": "concurrent_tests",
+          "title": "Write concurrent stress tests",
+          "detail": "Create tests that exercise critical paths from multiple threads simultaneously.",
+          "required": true
+        },
+        {
+          "id": "tsan_clean",
+          "title": "Achieve TSan-clean status",
+          "detail": "Iterate fixing races and re-running TSan until no extension races remain.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "id": "maintain",
+      "name": "Maintain",
+      "order": 5,
+      "items": [
+        {
+          "id": "tsan_ci",
+          "title": "Add TSan CI job",
+          "detail": "Run tests under TSan on every PR to prevent regressions.",
+          "required": true
+        },
+        {
+          "id": "document_invariants",
+          "title": "Document thread-safety invariants",
+          "detail": "Add comments documenting which locks protect which data, threading assumptions.",
+          "required": false
+        },
+        {
+          "id": "review_process",
+          "title": "Review new code for thread safety",
+          "detail": "Include thread-safety review in PR process for C code changes.",
+          "required": false
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/ft-review-toolkit/scripts/parse_tsan_report.py
+++ b/plugins/ft-review-toolkit/scripts/parse_tsan_report.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""Parse ThreadSanitizer (TSan) reports into structured findings.
+
+Parses TSan text output, groups races by location, deduplicates, and
+separates extension code races from CPython internal races.
+
+Unlike other scripts, this uses regex (not Tree-sitter) because TSan
+output is plain text, not C source.
+
+Usage:
+    python parse_tsan_report.py /path/to/tsan_report.txt
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+# Patterns for parsing TSan output.
+_WARNING_RE = re.compile(r"WARNING: ThreadSanitizer: (.+?)(?:\s+\(pid=\d+\))?\s*$")
+_ACCESS_RE = re.compile(
+    r"^\s+((?:Previous )?(?:[Ww]rite|[Rr]ead)) of size (\d+) "
+    r"at (0x[0-9a-f]+) by (.*?):\s*$"
+)
+_FRAME_RE = re.compile(r"^\s+#(\d+)\s+(\S+)\s+(.+?)(?:\s+\((.+?)\))?\s*$")
+_LOCATION_RE = re.compile(
+    r"^\s+Location is (.+?) of size (\d+) at (0x[0-9a-f]+)"
+    r"(?: \((.+?)\))?\s*$"
+)
+_THREAD_CREATE_RE = re.compile(
+    r"^\s+Thread T(\d+)\s+'?(.*?)'?\s+(?:\(tid=\d+.*?\)\s+)?created by (.*?) at:\s*$"
+)
+_SUMMARY_RE = re.compile(
+    r"^SUMMARY: ThreadSanitizer: (.+?)\s+(\S+?)(?::(\d+))?(?::(\d+))?"
+    r"\s+in\s+(.+?)\s*$"
+)
+_SEPARATOR_RE = re.compile(r"^={10,}$")
+
+# Patterns for identifying CPython internal frames.
+_CPYTHON_PATH_PATTERNS = [
+    r"/Python/",
+    r"/Objects/",
+    r"/Include/",
+    r"/Modules/_",
+    r"/Lib/",
+    r"/Parser/",
+    r"pycore_",
+    r"ceval\.c",
+    r"methodobject\.c",
+    r"call\.c",
+    r"classobject\.c",
+    r"descrobject\.c",
+    r"context\.c",
+    r"thread_pthread\.h",
+    r"_threadmodule\.c",
+]
+_CPYTHON_RE = re.compile("|".join(_CPYTHON_PATH_PATTERNS))
+
+
+def _parse_stack_frame(line: str) -> dict | None:
+    """Parse a single stack frame line.
+
+    Returns dict with: frame_num, function, location, module, file, line, col.
+    """
+    m = _FRAME_RE.match(line)
+    if not m:
+        return None
+
+    frame_num = int(m.group(1))
+    function = m.group(2)
+    location = m.group(3).strip()
+    module = m.group(4) or ""
+
+    # Parse file:line:col from location.
+    file_path = None
+    line_num = None
+    col_num = None
+    loc_match = re.match(r"(.+?):(\d+):(\d+)", location)
+    if loc_match:
+        file_path = loc_match.group(1)
+        line_num = int(loc_match.group(2))
+        col_num = int(loc_match.group(3))
+    elif location and location != "<null>":
+        file_path = location
+
+    return {
+        "frame_num": frame_num,
+        "function": function,
+        "location": location,
+        "module": module,
+        "file": file_path,
+        "line": line_num,
+        "col": col_num,
+    }
+
+
+def _is_cpython_frame(frame: dict) -> bool:
+    """Check if a stack frame is from CPython internals."""
+    loc = frame.get("location", "") or ""
+    module = frame.get("module", "") or ""
+    combined = loc + " " + module
+    return bool(_CPYTHON_RE.search(combined))
+
+
+def _get_extension_frame(frames: list[dict]) -> dict | None:
+    """Find the first non-CPython frame in a stack (the extension code)."""
+    for frame in frames:
+        if not _is_cpython_frame(frame):
+            return frame
+    return None
+
+
+def _parse_tsan_block(lines: list[str]) -> dict | None:
+    """Parse a single TSan warning block into a structured finding."""
+    if not lines:
+        return None
+
+    # Find the WARNING line.
+    race_type = None
+    for line in lines:
+        m = _WARNING_RE.match(line)
+        if m:
+            race_type = m.group(1)
+            break
+
+    if not race_type:
+        return None
+
+    # Parse access descriptors and their stack traces.
+    accesses = []
+    current_access = None
+    thread_info = []
+    location_info = None
+
+    for line in lines:
+        # Access header (Write/Read of size N).
+        access_m = _ACCESS_RE.match(line)
+        if access_m:
+            if current_access:
+                accesses.append(current_access)
+            current_access = {
+                "access_type": access_m.group(1).strip(),
+                "size": int(access_m.group(2)),
+                "address": access_m.group(3),
+                "thread": access_m.group(4).strip(),
+                "frames": [],
+            }
+            continue
+
+        # Stack frame.
+        frame = _parse_stack_frame(line)
+        if frame and current_access:
+            current_access["frames"].append(frame)
+            continue
+
+        # Location info.
+        loc_m = _LOCATION_RE.match(line)
+        if loc_m:
+            location_info = {
+                "description": loc_m.group(1),
+                "size": int(loc_m.group(2)),
+                "address": loc_m.group(3),
+                "module": loc_m.group(4) or "",
+            }
+            # If we were collecting an access, finish it.
+            if current_access:
+                accesses.append(current_access)
+                current_access = None
+            continue
+
+        # Thread creation info.
+        thread_m = _THREAD_CREATE_RE.match(line)
+        if thread_m:
+            if current_access:
+                accesses.append(current_access)
+                current_access = None
+            thread_info.append(
+                {
+                    "thread_id": int(thread_m.group(1)),
+                    "thread_name": thread_m.group(2),
+                    "creator": thread_m.group(3),
+                }
+            )
+            continue
+
+    # Don't forget the last access.
+    if current_access:
+        accesses.append(current_access)
+
+    # Parse summary line.
+    summary = None
+    for line in lines:
+        sum_m = _SUMMARY_RE.match(line)
+        if sum_m:
+            summary = {
+                "type": sum_m.group(1),
+                "file": sum_m.group(2),
+                "line": int(sum_m.group(3)) if sum_m.group(3) else None,
+                "col": int(sum_m.group(4)) if sum_m.group(4) else None,
+                "function": sum_m.group(5),
+            }
+            break
+
+    if not accesses:
+        return None
+
+    # Determine if this is an extension race or CPython internal.
+    ext_frames = []
+    for access in accesses:
+        ef = _get_extension_frame(access["frames"])
+        if ef:
+            ext_frames.append(ef)
+
+    is_extension_race = len(ext_frames) > 0
+    is_cpython_only = not is_extension_race
+
+    return {
+        "race_type": race_type,
+        "accesses": accesses,
+        "location": location_info,
+        "thread_info": thread_info,
+        "summary": summary,
+        "is_extension_race": is_extension_race,
+        "is_cpython_only": is_cpython_only,
+        "extension_frames": ext_frames,
+    }
+
+
+def _split_tsan_blocks(text: str) -> list[list[str]]:
+    """Split TSan output into individual warning blocks."""
+    blocks = []
+    current_block: list[str] = []
+    in_block = False
+
+    for line in text.splitlines():
+        if _SEPARATOR_RE.match(line):
+            if in_block and current_block:
+                blocks.append(current_block)
+                current_block = []
+                in_block = False
+            else:
+                in_block = True
+            continue
+        if in_block:
+            current_block.append(line)
+
+    if current_block:
+        blocks.append(current_block)
+
+    return blocks
+
+
+def _dedup_key(finding: dict) -> str:
+    """Generate a deduplication key from a finding's source locations."""
+    parts = []
+    for access in finding.get("accesses", []):
+        ef = _get_extension_frame(access["frames"])
+        if ef and ef.get("file") and ef.get("line"):
+            parts.append(f"{ef['file']}:{ef['line']}")
+        elif access["frames"]:
+            f0 = access["frames"][0]
+            parts.append(f"{f0.get('file', '?')}:{f0.get('line', '?')}")
+    parts.sort()
+    return "|".join(parts)
+
+
+def _deduplicate_races(findings: list[dict]) -> list[dict]:
+    """Deduplicate findings by source location pair."""
+    seen: dict[str, int] = {}
+    deduped: list[dict] = []
+
+    for finding in findings:
+        key = _dedup_key(finding)
+        if key in seen:
+            idx = seen[key]
+            deduped[idx]["frequency"] = deduped[idx].get("frequency", 1) + 1
+        else:
+            seen[key] = len(deduped)
+            finding["frequency"] = 1
+            deduped.append(finding)
+
+    return deduped
+
+
+def _classify_severity(finding: dict) -> tuple[str, str]:
+    """Classify a finding's severity and ft classification."""
+    race_type = finding.get("race_type", "")
+    location = finding.get("location", {}) or {}
+    loc_desc = location.get("description", "")
+
+    # Check if it involves a global variable.
+    if "global" in loc_desc:
+        return "RACE", "CRITICAL"
+
+    # Check access types.
+    access_types = [
+        a.get("access_type", "").lower() for a in finding.get("accesses", [])
+    ]
+    has_write = any("write" in t for t in access_types)
+
+    if has_write and len(access_types) >= 2:
+        return "RACE", "HIGH"
+
+    if "data race" in race_type.lower():
+        return "RACE", "HIGH"
+
+    return "RACE", "MEDIUM"
+
+
+def analyze(target: str, *, max_files: int = 0) -> dict:
+    """Parse a TSan report file into structured findings.
+
+    Args:
+        target: Path to TSan report file.
+        max_files: Unused (kept for API compatibility).
+
+    Returns JSON envelope with findings.
+    """
+    report_path = Path(target).resolve()
+
+    if not report_path.exists():
+        return {
+            "error": f"TSan report not found: {report_path}",
+            "report_path": str(report_path),
+        }
+
+    try:
+        text = report_path.read_text(encoding="utf-8", errors="replace")
+    except OSError as e:
+        return {"error": f"Failed to read report: {e}", "report_path": str(report_path)}
+
+    # Split into blocks and parse each.
+    blocks = _split_tsan_blocks(text)
+    raw_findings = []
+    for block in blocks:
+        finding = _parse_tsan_block(block)
+        if finding:
+            raw_findings.append(finding)
+
+    # Deduplicate.
+    deduped = _deduplicate_races(raw_findings)
+
+    # Classify each finding.
+    findings = []
+    for finding in deduped:
+        classification, severity = _classify_severity(finding)
+        finding["classification"] = classification
+        finding["severity"] = severity
+        findings.append(finding)
+
+    # Separate extension vs CPython races.
+    extension_races = [f for f in findings if f["is_extension_race"]]
+    cpython_races = [f for f in findings if f["is_cpython_only"]]
+
+    # Build summary.
+    return {
+        "report_path": str(report_path),
+        "total_warnings": len(raw_findings),
+        "unique_races": len(deduped),
+        "extension_races": len(extension_races),
+        "cpython_internal_races": len(cpython_races),
+        "findings": findings,
+        "summary": {
+            "total_findings": len(findings),
+            "by_classification": {
+                "RACE": len([f for f in findings if f["classification"] == "RACE"]),
+            },
+            "by_severity": {
+                s: len([f for f in findings if f["severity"] == s])
+                for s in ("CRITICAL", "HIGH", "MEDIUM", "LOW")
+                if any(f["severity"] == s for f in findings)
+            },
+            "actionable": len(extension_races),
+            "cpython_internal": len(cpython_races),
+        },
+    }
+
+
+def main() -> None:
+    """CLI entry point."""
+    if len(sys.argv) < 2:
+        print(json.dumps({"error": "Usage: parse_tsan_report.py <report_file>"}))
+        sys.exit(2)
+
+    target = sys.argv[1]
+    try:
+        result = analyze(target)
+        if "error" in result:
+            json.dump(result, sys.stdout, indent=2)
+            sys.stdout.write("\n")
+            sys.exit(1)
+        json.dump(result, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    except Exception as e:
+        json.dump({"error": str(e), "type": type(e).__name__}, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_parse_tsan_report.py
+++ b/tests/test_parse_tsan_report.py
@@ -1,0 +1,310 @@
+"""Tests for parse_tsan_report.py — TSan report parsing."""
+
+import unittest
+from helpers import import_script, TempExtension
+
+tsan = import_script("parse_tsan_report")
+
+# Real TSan report format from a racy C extension.
+SAMPLE_TSAN_REPORT = """\
+==================
+WARNING: ThreadSanitizer: data race (pid=835840)
+  Write of size 4 at 0x7ffff6504134 by thread T2:
+    #0 racy_increment /tmp/racy_ext/racymod.c:10:20 (racymod.cpython-314td-x86_64-linux-gnu.so+0x11e0)
+    #1 cfunction_vectorcall_NOARGS /home/user/cpython/Objects/methodobject.c:508:24 (python+0x354640)
+    #2 _PyObject_VectorcallTstate /home/user/cpython/./Include/internal/pycore_call.h:177:11 (python+0x27a1eb)
+    #3 PyObject_Vectorcall /home/user/cpython/Objects/call.c:327:12 (python+0x27bde0)
+
+  Previous write of size 4 at 0x7ffff6504134 by thread T1:
+    #0 racy_increment /tmp/racy_ext/racymod.c:10:20 (racymod.cpython-314td-x86_64-linux-gnu.so+0x11e0)
+    #1 cfunction_vectorcall_NOARGS /home/user/cpython/Objects/methodobject.c:508:24 (python+0x354640)
+    #2 _PyObject_VectorcallTstate /home/user/cpython/./Include/internal/pycore_call.h:177:11 (python+0x27a1eb)
+
+  Location is global 'shared_counter' of size 4 at 0x7ffff6504134 (racymod.cpython-314td-x86_64-linux-gnu.so+0x4134)
+
+  Thread T2 'Thread-2 (hamme' (tid=835843, running) created by main thread at:
+    #0 pthread_create <null> (python+0xebeee)
+    #1 do_start_joinable_thread /home/user/cpython/Python/thread_pthread.h:289:14 (python+0x68edf0)
+
+  Thread T1 'Thread-1 (hamme' (tid=835842, running) created by main thread at:
+    #0 pthread_create <null> (python+0xebeee)
+    #1 do_start_joinable_thread /home/user/cpython/Python/thread_pthread.h:289:14 (python+0x68edf0)
+
+SUMMARY: ThreadSanitizer: data race /tmp/racy_ext/racymod.c:10:20 in racy_increment
+==================
+"""
+
+# Duplicate race (same location, different thread pair).
+DUPLICATE_RACE_REPORT = """\
+==================
+WARNING: ThreadSanitizer: data race (pid=1234)
+  Write of size 4 at 0x7fff00001000 by thread T3:
+    #0 racy_increment /tmp/racy_ext/racymod.c:10:20 (racymod.so+0x11e0)
+    #1 cfunction_vectorcall_NOARGS /home/user/cpython/Objects/methodobject.c:508:24 (python+0x354640)
+
+  Previous write of size 4 at 0x7fff00001000 by thread T4:
+    #0 racy_increment /tmp/racy_ext/racymod.c:10:20 (racymod.so+0x11e0)
+    #1 cfunction_vectorcall_NOARGS /home/user/cpython/Objects/methodobject.c:508:24 (python+0x354640)
+
+  Location is global 'shared_counter' of size 4 at 0x7fff00001000 (racymod.so+0x1000)
+
+SUMMARY: ThreadSanitizer: data race /tmp/racy_ext/racymod.c:10:20 in racy_increment
+==================
+==================
+WARNING: ThreadSanitizer: data race (pid=1234)
+  Write of size 4 at 0x7fff00001000 by thread T5:
+    #0 racy_increment /tmp/racy_ext/racymod.c:10:20 (racymod.so+0x11e0)
+    #1 cfunction_vectorcall_NOARGS /home/user/cpython/Objects/methodobject.c:508:24 (python+0x354640)
+
+  Previous write of size 4 at 0x7fff00001000 by thread T6:
+    #0 racy_increment /tmp/racy_ext/racymod.c:10:20 (racymod.so+0x11e0)
+    #1 cfunction_vectorcall_NOARGS /home/user/cpython/Objects/methodobject.c:508:24 (python+0x354640)
+
+  Location is global 'shared_counter' of size 4 at 0x7fff00001000 (racymod.so+0x1000)
+
+SUMMARY: ThreadSanitizer: data race /tmp/racy_ext/racymod.c:10:20 in racy_increment
+==================
+"""
+
+# CPython-internal-only race (no extension frames).
+CPYTHON_ONLY_RACE = """\
+==================
+WARNING: ThreadSanitizer: data race (pid=5555)
+  Read of size 8 at 0x7fff99990000 by thread T1:
+    #0 _PyEval_EvalFrameDefault /home/user/cpython/Python/generated_cases.c.h:1621:35 (python+0x5136b4)
+    #1 _PyEval_EvalFrame /home/user/cpython/./Include/internal/pycore_ceval.h:120:16 (python+0x5095d6)
+
+  Previous write of size 8 at 0x7fff99990000 by thread T2:
+    #0 _PyDict_SetItem_Take2 /home/user/cpython/Objects/dictobject.c:1234:5 (python+0x2a0000)
+    #1 PyDict_SetItem /home/user/cpython/Objects/dictobject.c:1500:12 (python+0x2a1000)
+
+SUMMARY: ThreadSanitizer: data race /home/user/cpython/Python/generated_cases.c.h:1621:35 in _PyEval_EvalFrameDefault
+==================
+"""
+
+# Multiple different races in one report.
+MULTI_RACE_REPORT = """\
+==================
+WARNING: ThreadSanitizer: data race (pid=1000)
+  Write of size 4 at 0x7fff00001000 by thread T1:
+    #0 update_counter /src/myext/counter.c:25:5 (myext.so+0x1100)
+    #1 cfunction_vectorcall_NOARGS /home/user/cpython/Objects/methodobject.c:508:24 (python+0x354640)
+
+  Previous read of size 4 at 0x7fff00001000 by thread T2:
+    #0 read_counter /src/myext/counter.c:30:12 (myext.so+0x1200)
+    #1 cfunction_vectorcall_NOARGS /home/user/cpython/Objects/methodobject.c:508:24 (python+0x354640)
+
+  Location is global 'g_counter' of size 4 at 0x7fff00001000 (myext.so+0x1000)
+
+SUMMARY: ThreadSanitizer: data race /src/myext/counter.c:25:5 in update_counter
+==================
+==================
+WARNING: ThreadSanitizer: data race (pid=1000)
+  Write of size 1 at 0x7fff00002000 by thread T1:
+    #0 set_flag /src/myext/flags.c:15:5 (myext.so+0x2100)
+    #1 cfunction_vectorcall_NOARGS /home/user/cpython/Objects/methodobject.c:508:24 (python+0x354640)
+
+  Previous read of size 1 at 0x7fff00002000 by thread T3:
+    #0 check_flag /src/myext/flags.c:20:9 (myext.so+0x2200)
+    #1 cfunction_vectorcall_NOARGS /home/user/cpython/Objects/methodobject.c:508:24 (python+0x354640)
+
+  Location is global 'enabled' of size 1 at 0x7fff00002000 (myext.so+0x2000)
+
+SUMMARY: ThreadSanitizer: data race /src/myext/flags.c:15:5 in set_flag
+==================
+"""
+
+EMPTY_REPORT = ""
+
+NO_TSAN_OUTPUT = """\
+All tests passed.
+55 passed in 3.09s
+"""
+
+
+class TestParseTsanReport(unittest.TestCase):
+    """Test TSan report parsing."""
+
+    def _write_report(self, root, content):
+        """Write report content to a file and return its path."""
+        report_path = root / "tsan_report.txt"
+        report_path.write_text(content, encoding="utf-8")
+        return str(report_path)
+
+    def test_basic_race_parsed(self):
+        """Basic data race is parsed correctly."""
+        with TempExtension({}) as root:
+            path = self._write_report(root, SAMPLE_TSAN_REPORT)
+            result = tsan.analyze(path)
+            self.assertEqual(result["total_warnings"], 1)
+            self.assertEqual(result["unique_races"], 1)
+            self.assertEqual(len(result["findings"]), 1)
+
+            finding = result["findings"][0]
+            self.assertEqual(finding["race_type"], "data race")
+            self.assertTrue(finding["is_extension_race"])
+            self.assertFalse(finding["is_cpython_only"])
+
+    def test_accesses_parsed(self):
+        """Access descriptors (write/read, thread, frames) are parsed."""
+        with TempExtension({}) as root:
+            path = self._write_report(root, SAMPLE_TSAN_REPORT)
+            result = tsan.analyze(path)
+            finding = result["findings"][0]
+
+            self.assertEqual(len(finding["accesses"]), 2)
+            # First access is a Write.
+            self.assertIn("Write", finding["accesses"][0]["access_type"])
+            # Both have frames.
+            self.assertGreater(len(finding["accesses"][0]["frames"]), 0)
+            self.assertGreater(len(finding["accesses"][1]["frames"]), 0)
+
+    def test_stack_frames_parsed(self):
+        """Stack frames include file, line, function."""
+        with TempExtension({}) as root:
+            path = self._write_report(root, SAMPLE_TSAN_REPORT)
+            result = tsan.analyze(path)
+            finding = result["findings"][0]
+            frame = finding["accesses"][0]["frames"][0]
+
+            self.assertEqual(frame["function"], "racy_increment")
+            self.assertEqual(frame["file"], "/tmp/racy_ext/racymod.c")
+            self.assertEqual(frame["line"], 10)
+            self.assertEqual(frame["col"], 20)
+
+    def test_location_parsed(self):
+        """Global variable location info is parsed."""
+        with TempExtension({}) as root:
+            path = self._write_report(root, SAMPLE_TSAN_REPORT)
+            result = tsan.analyze(path)
+            finding = result["findings"][0]
+
+            self.assertIsNotNone(finding["location"])
+            self.assertIn("shared_counter", finding["location"]["description"])
+
+    def test_global_variable_critical(self):
+        """Race on global variable gets CRITICAL severity."""
+        with TempExtension({}) as root:
+            path = self._write_report(root, SAMPLE_TSAN_REPORT)
+            result = tsan.analyze(path)
+            finding = result["findings"][0]
+
+            self.assertEqual(finding["classification"], "RACE")
+            self.assertEqual(finding["severity"], "CRITICAL")
+
+    def test_deduplication(self):
+        """Duplicate races (same location pair) are deduplicated."""
+        with TempExtension({}) as root:
+            path = self._write_report(root, DUPLICATE_RACE_REPORT)
+            result = tsan.analyze(path)
+            self.assertEqual(result["total_warnings"], 2)
+            self.assertEqual(result["unique_races"], 1)
+            self.assertEqual(result["findings"][0]["frequency"], 2)
+
+    def test_cpython_only_race(self):
+        """CPython-internal-only race is identified."""
+        with TempExtension({}) as root:
+            path = self._write_report(root, CPYTHON_ONLY_RACE)
+            result = tsan.analyze(path)
+            self.assertEqual(result["extension_races"], 0)
+            self.assertEqual(result["cpython_internal_races"], 1)
+            self.assertTrue(result["findings"][0]["is_cpython_only"])
+
+    def test_multiple_different_races(self):
+        """Multiple different races are parsed as separate findings."""
+        with TempExtension({}) as root:
+            path = self._write_report(root, MULTI_RACE_REPORT)
+            result = tsan.analyze(path)
+            self.assertEqual(result["unique_races"], 2)
+
+            # Both should be extension races.
+            self.assertEqual(result["extension_races"], 2)
+
+            funcs = {
+                f["summary"]["function"] for f in result["findings"] if f.get("summary")
+            }
+            self.assertIn("update_counter", funcs)
+            self.assertIn("set_flag", funcs)
+
+    def test_empty_report(self):
+        """Empty report produces zero findings."""
+        with TempExtension({}) as root:
+            path = self._write_report(root, EMPTY_REPORT)
+            result = tsan.analyze(path)
+            self.assertEqual(result["total_warnings"], 0)
+            self.assertEqual(len(result["findings"]), 0)
+
+    def test_no_tsan_output(self):
+        """Non-TSan output produces zero findings."""
+        with TempExtension({}) as root:
+            path = self._write_report(root, NO_TSAN_OUTPUT)
+            result = tsan.analyze(path)
+            self.assertEqual(result["total_warnings"], 0)
+
+    def test_missing_file(self):
+        """Missing report file returns error."""
+        result = tsan.analyze("/nonexistent/path/report.txt")
+        self.assertIn("error", result)
+
+    def test_summary_structure(self):
+        """Output has expected summary structure."""
+        with TempExtension({}) as root:
+            path = self._write_report(root, SAMPLE_TSAN_REPORT)
+            result = tsan.analyze(path)
+            self.assertIn("report_path", result)
+            self.assertIn("total_warnings", result)
+            self.assertIn("unique_races", result)
+            self.assertIn("extension_races", result)
+            self.assertIn("cpython_internal_races", result)
+            self.assertIn("findings", result)
+            self.assertIn("summary", result)
+            self.assertIn("actionable", result["summary"])
+
+    def test_thread_info_parsed(self):
+        """Thread creation info is parsed."""
+        with TempExtension({}) as root:
+            path = self._write_report(root, SAMPLE_TSAN_REPORT)
+            result = tsan.analyze(path)
+            finding = result["findings"][0]
+            self.assertGreater(len(finding["thread_info"]), 0)
+
+
+class TestParseStackFrame(unittest.TestCase):
+    """Test individual frame parsing."""
+
+    def test_frame_with_file_line_col(self):
+        """Frame with file:line:col is parsed correctly."""
+        line = "    #0 racy_increment /tmp/racymod.c:10:20 (racymod.so+0x11e0)"
+        frame = tsan._parse_stack_frame(line)
+        self.assertIsNotNone(frame)
+        self.assertEqual(frame["function"], "racy_increment")
+        self.assertEqual(frame["file"], "/tmp/racymod.c")
+        self.assertEqual(frame["line"], 10)
+        self.assertEqual(frame["col"], 20)
+
+    def test_frame_with_null_location(self):
+        """Frame with <null> location is parsed."""
+        line = "    #0 pthread_create <null> (python+0xebeee)"
+        frame = tsan._parse_stack_frame(line)
+        self.assertIsNotNone(frame)
+        self.assertEqual(frame["function"], "pthread_create")
+
+    def test_cpython_frame_detected(self):
+        """CPython internal frame is detected."""
+        frame = {
+            "location": "/home/user/cpython/Objects/methodobject.c:508:24",
+            "module": "python+0x354640",
+        }
+        self.assertTrue(tsan._is_cpython_frame(frame))
+
+    def test_extension_frame_not_cpython(self):
+        """Extension frame is not detected as CPython."""
+        frame = {
+            "location": "/tmp/racy_ext/racymod.c:10:20",
+            "module": "racymod.so+0x11e0",
+        }
+        self.assertFalse(tsan._is_cpython_frame(frame))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `parse_tsan_report.py` — regex-based TSan report parser with deduplication, extension/CPython separation, severity classification (17 tests)
- Add 3 agents: `tsan-report-analyzer`, `stop-the-world-advisor`, `migration-planner`
- Add `plan` command and `ft_migration_checklist.json` data file
- Validated with real TSan report from deliberately racy extension under TSan-enabled free-threaded Python 3.14

## Test plan
- [x] 71 tests pass (17 new TSan parser tests)
- [x] Lint clean (ruff check + ruff format)
- [x] Real TSan report correctly parsed: 2 raw warnings → 1 unique CRITICAL race, frequency=2, extension code identified
- [x] Parser handles: empty reports, non-TSan output, missing files, CPython-only races, multiple different races, deduplication

Closes #3

Generated with [Claude Code](https://claude.com/claude-code)