### PR TITLE
Improve tsan-stress-generator robustness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `parse_tsan_report.py` — ThreadSanitizer report parsing, deduplication, and triage
 - `tsan-report-analyzer` agent
 - `stop-the-world-advisor` agent — synchronization mechanism recommendations
-- `tsan-stress-generator` agent — generate concurrent stress test scripts for TSan race detection
+- `tsan-stress-generator` agent — generate concurrent stress test scripts for TSan race detection, with TSan auto-detection, fork-based subprocess isolation, and per-scenario timeout
 - `migration-planner` agent — phased free-threading migration plans
 - `plan` command — produce a tailored migration plan
 - Data files: `thread_safe_apis.json`, `lock_macros.json`, `atomic_patterns.json`, `critical_section_apis.json`, `ft_migration_checklist.json`

--- a/plugins/ft-review-toolkit/agents/tsan-stress-generator.md
+++ b/plugins/ft-review-toolkit/agents/tsan-stress-generator.md
@@ -118,6 +118,9 @@ Produce a **self-contained** Python script with these properties:
 5. **Configurable** — THREADS and ITERATIONS as constants at the top
 6. **Error-tolerant** — catch exceptions in threads (we want races, not crashes from bad args)
 7. **Barrier synchronization** — use `threading.Barrier` to start all threads simultaneously
+8. **TSan auto-detection** — detect TSan builds via sysconfig CFLAGS and reduce threads/iterations (TSan finds races on first occurrence; volume just adds overhead)
+9. **Subprocess isolation** — each scenario runs in a `os.fork()`ed child process so SEGVs don't kill the parent. TSan stderr from children goes to the same fd. Parent uses `os.waitpid` with `WNOHANG` polling loop for timeout.
+10. **Per-scenario timeout** — kill child after SCENARIO_TIMEOUT seconds (TSan overhead on heavily raced code can cause near-infinite runtimes)
 
 ## Output Format
 
@@ -133,11 +136,29 @@ Run with TSan-enabled free-threaded Python:
 Then triage with:
     /ft-review-toolkit:explore . tsan tsan_report.txt
 """
-import threading
+import os
+import signal
 import sys
+import threading
+import time
 
 THREADS = 8
 ITERATIONS = 10_000
+SCENARIO_TIMEOUT = 60  # seconds — kill child if TSan overhead stalls it
+
+
+# TSan adds 5-15x overhead and finds races on first occurrence.
+def _is_tsan_build():
+    try:
+        import sysconfig
+        cflags = (sysconfig.get_config_var("CFLAGS") or "").lower()
+        return "fsanitize=thread" in cflags
+    except Exception:
+        return False
+
+if _is_tsan_build():
+    THREADS = min(THREADS, 4)
+    ITERATIONS = min(ITERATIONS, 200)
 
 # Suppress GIL warning if present
 import warnings
@@ -147,8 +168,49 @@ import <extension>
 
 
 def run_scenario(name, target_fns, thread_counts=None):
-    """Run a stress scenario with multiple thread groups."""
+    """Run a stress scenario, isolated in a forked subprocess.
+
+    Each scenario runs in a child process so SEGVs don't kill the parent.
+    TSan stderr from children goes to the same fd.
+    """
     print(f"  Running: {name}...", end=" ", flush=True)
+
+    pid = os.fork()
+    if pid == 0:
+        try:
+            _run_scenario_threads(target_fns, thread_counts)
+            os._exit(0)
+        except SystemExit as e:
+            os._exit(e.code if isinstance(e.code, int) else 1)
+        except Exception:
+            os._exit(1)
+
+    # Parent waits with timeout.
+    deadline = time.monotonic() + SCENARIO_TIMEOUT
+    wait_status = None
+    while time.monotonic() < deadline:
+        pid_result, status = os.waitpid(pid, os.WNOHANG)
+        if pid_result != 0:
+            wait_status = status
+            break
+        time.sleep(0.1)
+
+    if wait_status is None:
+        os.kill(pid, signal.SIGKILL)
+        os.waitpid(pid, 0)
+        print(f"TIMEOUT ({SCENARIO_TIMEOUT}s)")
+    elif os.WIFSIGNALED(wait_status):
+        sig = os.WTERMSIG(wait_status)
+        signame = signal.Signals(sig).name if sig in signal.Signals._value2member_map_ else str(sig)
+        print(f"CRASH ({signame})")
+    elif os.WIFEXITED(wait_status) and os.WEXITSTATUS(wait_status) != 0:
+        print(f"FAIL (exit {os.WEXITSTATUS(wait_status)})")
+    else:
+        print("OK")
+
+
+def _run_scenario_threads(target_fns, thread_counts=None):
+    """Run target functions in threads with barrier synchronization."""
     if thread_counts is None:
         thread_counts = [THREADS] * len(target_fns)
 
@@ -175,8 +237,8 @@ def run_scenario(name, target_fns, thread_counts=None):
     for t in threads:
         t.join(timeout=30)
 
-    status = "OK" if not errors else f"{len(errors)} errors"
-    print(status)
+    if errors:
+        sys.exit(1)
 
 
 def scenario_1():


### PR DESCRIPTION
## Summary
- Add TSan auto-detection (reduce threads/iterations under TSan since races are found on first occurrence)
- Add fork-based subprocess isolation (SEGVs in one scenario don't kill the pipeline)
- Add per-scenario timeout (prevent TSan overhead from stalling on heavily raced code)

Validated on multidict: 16 warnings from 1 scenario before → 217 warnings across all 9 scenarios after (66 unique locations, 95 deduplicated findings).

## Test plan
- [x] 71 tests pass
- [x] Validated end-to-end on multidict with TSan-enabled free-threaded Python 3.14
- [x] All 9 scenarios complete (including previously-hanging repr/comparison)
- [x] Fork isolation survives 2 SEGVs without killing parent

Closes #7

Generated with [Claude Code](https://claude.com/claude-code)