### PR TITLE
Fix code-review-toolkit explore findings: silent failures, test gaps, refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `_PyEval_StopTheWorld`/`_PyEval_StartTheWorld` pairing in lock discipline scanner
 - Enhanced `stop-the-world-advisor` with STW safety contract guidance
 
+### Fixed
+- Silent data-loading failures in 4 scanners: `scan_shared_state.py`, `scan_unsafe_apis.py`, `scan_lock_discipline.py`, `scan_stw_safety.py` now warn to stderr when JSON data files fail to load instead of silently producing zero findings.
+- Conditional test assertions in `test_scan_shared_state.py` and `test_scan_atomic_candidates.py` that silently passed when no findings were produced.
+- Plugin metadata counts in `plugin.json` (9 agents → 10, 6 scripts → 7).
+- Missing `test_output_envelope` assertions for `functions_analyzed` and `skipped_files` in `test_scan_lock_discipline.py` and `test_scan_atomic_candidates.py`.
+- Redundant `source_bytes.decode()` called twice per declaration in `scan_shared_state.py:_analyze_file`.
+
 ### Enhanced
+- All 7 `main()` functions now print full tracebacks to stderr before outputting JSON error envelopes, improving debuggability.
+- Extracted duplicated helpers (`is_thread_local`, `is_init_function`, `is_in_region`) from individual scanners into `scan_common.py`, eliminating copy-paste across `scan_shared_state.py`, `scan_atomic_candidates.py`, `scan_unsafe_apis.py`, and `scan_stw_safety.py`.
+- Documented JSON envelope variants for `parse_tsan_report.py`, `analyze_ft_history.py`, and `scan_stw_safety.py` in CLAUDE.md.
+- Listed all script-backed agents explicitly in CLAUDE.md agents section.
+
+### Enhanced (previous)
 - Revised STW safety contract based on YiFei Zhu's analysis of CPython allocation paths: object allocation is safe during STW on Python 3.14+ (GC runs only on eval breaker), `PyErr_NoMemory`/`PyErr_SetString` conditionally safe, dict ops safe with `CheckExact` types. Updated `stw_safe_apis.json`, `scan_stw_safety.py`, and tests.
 - Port cext-review-toolkit enhancements: global non-restarting finding numbering in `explore` reports (cext #33), `extract_nearby_comments()`/`has_safety_annotation()` in `scan_common.py` for comment-aware triage (cext #30), enhanced deduplication guidance with intra-agent, cross-agent, and TSan dedup rules (cext #28).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,8 @@ All scripts live in `plugins/ft-review-toolkit/scripts/`. Every analysis script 
 
 **Script calling convention:** Every analysis script exposes `analyze(target: str, *, max_files: int = 0) -> dict` returning a JSON envelope with `{project_root, scan_root, files_analyzed, functions_analyzed, findings, summary, skipped_files}`. Exception: `analyze_ft_history.py` takes `argv` (matching cext-review-toolkit convention). Exception: `parse_tsan_report.py` takes `target` as a TSan report file path, not a source directory.
 
+**Envelope variants:** `parse_tsan_report.py` uses a custom envelope (`report_path`, `total_warnings`, `unique_races`, `extension_races`, etc.) since it processes TSan text, not C source. `analyze_ft_history.py` uses a custom envelope (`time_range`, `migration_timeline`, `ft_commit_details`, `file_churn`, etc.) since it processes git history. `scan_stw_safety.py` extends the standard envelope with `stw_functions` and `function_classifications`.
+
 ### Classification system
 
 Every finding is tagged with a classification and severity:
@@ -94,7 +96,7 @@ Severities: **CRITICAL**, **HIGH**, **MEDIUM**, **LOW**
 
 ### Agents
 
-Markdown files in `plugins/ft-review-toolkit/agents/`. YAML frontmatter with `name`, `description` (with `<example>` tags), `model: opus`, `color`. Script-backed agents have 3 phases: run scanner, triage findings, pattern review beyond script. Qualitative agents (stop-the-world-advisor, migration-planner, tsan-stress-generator) use Grep/Read/Bash directly.
+Markdown files in `plugins/ft-review-toolkit/agents/`. YAML frontmatter with `name`, `description` (with `<example>` tags), `model: opus`, `color`. Script-backed agents (shared-state-auditor, unsafe-api-detector, lock-discipline-checker, atomic-candidate-finder, tsan-report-analyzer, ft-history-analyzer, stw-safety-checker) have 3 phases: run scanner, triage findings, pattern review beyond script. Qualitative agents (stop-the-world-advisor, migration-planner, tsan-stress-generator) use Grep/Read/Bash directly.
 
 ## Testing notes
 - All tests use `unittest` — never pytest

--- a/plugins/ft-review-toolkit/.claude-plugin/plugin.json
+++ b/plugins/ft-review-toolkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ft-review-toolkit",
   "version": "0.2.0",
-  "description": "Free-threading migration toolkit for CPython C extensions. Finds thread-safety bugs (data races, unprotected shared state, unsafe API usage, lock discipline issues), plans migrations to free-threaded Python (PEP 703), triages ThreadSanitizer reports, generates concurrent stress tests for TSan, and produces readiness assessments. 9 agents, 6 scripts, 3 commands. Tree-sitter-powered C/C++ parsing.",
+  "description": "Free-threading migration toolkit for CPython C extensions. Finds thread-safety bugs (data races, unprotected shared state, unsafe API usage, lock discipline issues), plans migrations to free-threaded Python (PEP 703), triages ThreadSanitizer reports, generates concurrent stress tests for TSan, and produces readiness assessments. 10 agents, 7 scripts, 3 commands. Tree-sitter-powered C/C++ parsing.",
   "author": {
     "name": "Danzin"
   }

--- a/plugins/ft-review-toolkit/scripts/analyze_ft_history.py
+++ b/plugins/ft-review-toolkit/scripts/analyze_ft_history.py
@@ -23,6 +23,7 @@ import json
 import re
 import subprocess
 import sys
+import traceback
 import time
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
@@ -676,6 +677,7 @@ def main() -> None:
         json.dump(result, sys.stdout, indent=2)
         sys.stdout.write("\n")
     except Exception as e:
+        print(traceback.format_exc(), file=sys.stderr)
         json.dump({"error": str(e), "type": type(e).__name__}, sys.stdout, indent=2)
         sys.stdout.write("\n")
         sys.exit(1)

--- a/plugins/ft-review-toolkit/scripts/parse_tsan_report.py
+++ b/plugins/ft-review-toolkit/scripts/parse_tsan_report.py
@@ -14,6 +14,7 @@ Usage:
 import json
 import re
 import sys
+import traceback
 from pathlib import Path
 
 
@@ -393,6 +394,7 @@ def main() -> None:
         json.dump(result, sys.stdout, indent=2)
         sys.stdout.write("\n")
     except Exception as e:
+        print(traceback.format_exc(), file=sys.stderr)
         json.dump({"error": str(e), "type": type(e).__name__}, sys.stdout, indent=2)
         sys.stdout.write("\n")
         sys.exit(1)

--- a/plugins/ft-review-toolkit/scripts/scan_atomic_candidates.py
+++ b/plugins/ft-review-toolkit/scripts/scan_atomic_candidates.py
@@ -11,10 +11,17 @@ Usage:
 import json
 import re
 import sys
+import traceback
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from scan_common import discover_c_files, find_project_root, parse_common_args
+from scan_common import (
+    discover_c_files,
+    find_project_root,
+    is_init_function,
+    is_thread_local,
+    parse_common_args,
+)
 from tree_sitter_utils import (
     extract_functions,
     extract_static_declarations,
@@ -27,18 +34,8 @@ _ATOMIC_TYPE_PATTERNS = re.compile(
     r"_Py_atomic_\w+|std::atomic|_Atomic\b|atomic_\w+", re.IGNORECASE
 )
 
-_THREAD_LOCAL_KEYWORDS = frozenset(
-    {
-        "__thread",
-        "_Thread_local",
-        "thread_local",
-        "_Py_thread_local",
-    }
-)
-
-_INIT_FUNCTION_RE = re.compile(
-    r"^(PyInit_\w+|PyMODINIT_FUNC|module_init|init_\w+|_init\w*|exec_\w+)$"
-)
+_is_thread_local = is_thread_local
+_is_init_function = is_init_function
 
 _PRIMITIVE_TYPES = frozenset(
     {
@@ -68,19 +65,6 @@ _PRIMITIVE_TYPES = frozenset(
 def _is_atomic_type(decl_type: str) -> bool:
     """Check if a type is already an atomic type."""
     return bool(_ATOMIC_TYPE_PATTERNS.search(decl_type))
-
-
-def _is_thread_local(decl_type: str, source_line: str) -> bool:
-    """Check if a declaration uses thread-local storage."""
-    for kw in _THREAD_LOCAL_KEYWORDS:
-        if kw in decl_type or kw in source_line:
-            return True
-    return False
-
-
-def _is_init_function(name: str) -> bool:
-    """Check if a function name looks like a module init function."""
-    return bool(_INIT_FUNCTION_RE.match(name))
 
 
 def _is_primitive_type(decl_type: str) -> bool:
@@ -372,6 +356,7 @@ def main() -> None:
         json.dump(result, sys.stdout, indent=2)
         sys.stdout.write("\n")
     except Exception as e:
+        print(traceback.format_exc(), file=sys.stderr)
         json.dump({"error": str(e), "type": type(e).__name__}, sys.stdout, indent=2)
         sys.stdout.write("\n")
         sys.exit(1)

--- a/plugins/ft-review-toolkit/scripts/scan_common.py
+++ b/plugins/ft-review-toolkit/scripts/scan_common.py
@@ -6,6 +6,7 @@ API table loading, and AST helpers used across multiple scanner scripts.
 """
 
 import json
+import re
 import sys
 from collections.abc import Generator
 from pathlib import Path
@@ -143,6 +144,35 @@ def find_assigned_variable(call_node, source_bytes: bytes) -> str | None:
             break
         node = node.parent
     return None
+
+
+_INIT_FUNCTION_RE = re.compile(
+    r"^(PyInit_\w+|PyMODINIT_FUNC|module_init|init_\w+|_init\w*|exec_\w+)$"
+)
+
+_THREAD_LOCAL_KEYWORDS = frozenset(
+    {
+        "__thread",
+        "_Thread_local",
+        "thread_local",
+        "_Py_thread_local",
+    }
+)
+
+
+def is_thread_local(decl_type: str, source_line: str) -> bool:
+    """Check if a declaration uses thread-local storage."""
+    return any(kw in decl_type or kw in source_line for kw in _THREAD_LOCAL_KEYWORDS)
+
+
+def is_init_function(name: str) -> bool:
+    """Check if a function name looks like a module init function."""
+    return bool(_INIT_FUNCTION_RE.match(name))
+
+
+def is_in_region(offset: int, regions: list[tuple[int, int]]) -> bool:
+    """Check if a byte offset falls within any of the given regions."""
+    return any(start <= offset < end for start, end in regions)
 
 
 def extract_nearby_comments(

--- a/plugins/ft-review-toolkit/scripts/scan_lock_discipline.py
+++ b/plugins/ft-review-toolkit/scripts/scan_lock_discipline.py
@@ -11,6 +11,7 @@ Usage:
 import json
 import re
 import sys
+import traceback
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -36,7 +37,11 @@ def _load_lock_macros() -> dict:
     try:
         with open(_DATA_DIR / "lock_macros.json", encoding="utf-8") as f:
             _lock_data = json.load(f)
-    except (OSError, json.JSONDecodeError):
+    except (OSError, json.JSONDecodeError) as e:
+        print(
+            f"Warning: failed to load lock_macros.json: {e}",
+            file=sys.stderr,
+        )
         _lock_data = {}
     return _lock_data
 
@@ -426,6 +431,7 @@ def main() -> None:
         json.dump(result, sys.stdout, indent=2)
         sys.stdout.write("\n")
     except Exception as e:
+        print(traceback.format_exc(), file=sys.stderr)
         json.dump({"error": str(e), "type": type(e).__name__}, sys.stdout, indent=2)
         sys.stdout.write("\n")
         sys.exit(1)

--- a/plugins/ft-review-toolkit/scripts/scan_shared_state.py
+++ b/plugins/ft-review-toolkit/scripts/scan_shared_state.py
@@ -10,12 +10,18 @@ Usage:
 """
 
 import json
-import re
 import sys
+import traceback
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from scan_common import discover_c_files, find_project_root, parse_common_args
+from scan_common import (
+    discover_c_files,
+    find_project_root,
+    is_init_function,
+    is_thread_local,
+    parse_common_args,
+)
 from tree_sitter_utils import (
     extract_functions,
     extract_static_declarations,
@@ -25,19 +31,6 @@ from tree_sitter_utils import (
 )
 
 _DATA_DIR = Path(__file__).resolve().parent.parent / "data"
-
-_INIT_FUNCTION_PATTERNS = re.compile(
-    r"^(PyInit_\w+|PyMODINIT_FUNC|module_init|init_\w+|_init\w*|exec_\w+)$"
-)
-
-_THREAD_LOCAL_KEYWORDS = frozenset(
-    {
-        "__thread",
-        "_Thread_local",
-        "thread_local",
-        "_Py_thread_local",
-    }
-)
 
 _LOCK_APIS: set[str] = set()
 
@@ -52,22 +45,16 @@ def _load_lock_apis() -> set[str]:
             data = json.load(f)
         _LOCK_APIS = set(data.get("all_acquire_macros", []))
         _LOCK_APIS |= set(data.get("all_release_macros", []))
-    except (OSError, json.JSONDecodeError):
-        pass
+    except (OSError, json.JSONDecodeError) as e:
+        print(
+            f"Warning: failed to load lock_macros.json: {e}",
+            file=sys.stderr,
+        )
     return _LOCK_APIS
 
 
-def _is_thread_local(decl_type: str, source_line: str) -> bool:
-    """Check if a declaration uses thread-local storage."""
-    for kw in _THREAD_LOCAL_KEYWORDS:
-        if kw in decl_type or kw in source_line:
-            return True
-    return False
-
-
-def _is_init_function(name: str) -> bool:
-    """Check if a function name looks like a module init function."""
-    return bool(_INIT_FUNCTION_PATTERNS.match(name))
+_is_thread_local = is_thread_local
+_is_init_function = is_init_function
 
 
 def _classify_declaration(decl: dict) -> str:
@@ -186,14 +173,14 @@ def _analyze_file(filepath: Path, source_bytes: bytes) -> list[dict]:
     for f in findings:
         f["file"] = rel_path
 
+    # Decode once for source line lookups.
+    source_lines = source_bytes.decode("utf-8", errors="replace").splitlines()
+
     # Analyze each static declaration.
     for decl in static_decls:
         source_line = (
-            source_bytes.decode("utf-8", errors="replace").splitlines()[
-                decl["start_line"] - 1
-            ]
-            if decl["start_line"]
-            <= len(source_bytes.decode("utf-8", errors="replace").splitlines())
+            source_lines[decl["start_line"] - 1]
+            if decl["start_line"] <= len(source_lines)
             else ""
         )
 
@@ -441,6 +428,7 @@ def main() -> None:
         json.dump(result, sys.stdout, indent=2)
         sys.stdout.write("\n")
     except Exception as e:
+        print(traceback.format_exc(), file=sys.stderr)
         json.dump({"error": str(e), "type": type(e).__name__}, sys.stdout, indent=2)
         sys.stdout.write("\n")
         sys.exit(1)

--- a/plugins/ft-review-toolkit/scripts/scan_stw_safety.py
+++ b/plugins/ft-review-toolkit/scripts/scan_stw_safety.py
@@ -12,10 +12,16 @@ Usage:
 import json
 import re
 import sys
+import traceback
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from scan_common import discover_c_files, find_project_root, parse_common_args
+from scan_common import (
+    discover_c_files,
+    find_project_root,
+    is_in_region,
+    parse_common_args,
+)
 from tree_sitter_utils import (
     extract_functions,
     find_calls_in_scope,
@@ -35,7 +41,11 @@ def _load_stw_apis() -> dict:
     try:
         with open(_DATA_DIR / "stw_safe_apis.json", encoding="utf-8") as f:
             _stw_data = json.load(f)
-    except (OSError, json.JSONDecodeError):
+    except (OSError, json.JSONDecodeError) as e:
+        print(
+            f"Warning: failed to load stw_safe_apis.json: {e}",
+            file=sys.stderr,
+        )
         _stw_data = {}
     return _stw_data
 
@@ -153,12 +163,7 @@ def _find_stw_regions(body_text: str) -> list[tuple[int, int]]:
     return regions
 
 
-def _is_in_region(offset: int, regions: list[tuple[int, int]]) -> bool:
-    """Check if a byte offset falls within any of the given regions."""
-    for start, end in regions:
-        if start <= offset < end:
-            return True
-    return False
+_is_in_region = is_in_region
 
 
 def _classify_call(func_name: str, safe_apis: set[str], unsafe_apis: set[str]) -> str:
@@ -509,6 +514,7 @@ def main() -> None:
         json.dump(result, sys.stdout, indent=2)
         sys.stdout.write("\n")
     except Exception as e:
+        print(traceback.format_exc(), file=sys.stderr)
         json.dump({"error": str(e), "type": type(e).__name__}, sys.stdout, indent=2)
         sys.stdout.write("\n")
         sys.exit(1)

--- a/plugins/ft-review-toolkit/scripts/scan_unsafe_apis.py
+++ b/plugins/ft-review-toolkit/scripts/scan_unsafe_apis.py
@@ -12,10 +12,16 @@ Usage:
 import json
 import re
 import sys
+import traceback
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from scan_common import discover_c_files, find_project_root, parse_common_args
+from scan_common import (
+    discover_c_files,
+    find_project_root,
+    is_in_region,
+    parse_common_args,
+)
 from tree_sitter_utils import (
     extract_functions,
     extract_static_declarations,
@@ -36,7 +42,11 @@ def _load_thread_safe_apis() -> dict:
     try:
         with open(_DATA_DIR / "thread_safe_apis.json", encoding="utf-8") as f:
             _thread_safe_data = json.load(f)
-    except (OSError, json.JSONDecodeError):
+    except (OSError, json.JSONDecodeError) as e:
+        print(
+            f"Warning: failed to load thread_safe_apis.json: {e}",
+            file=sys.stderr,
+        )
         _thread_safe_data = {}
     return _thread_safe_data
 
@@ -65,12 +75,7 @@ def _find_gil_released_regions(body_text: str) -> list[tuple[int, int]]:
     return regions
 
 
-def _is_in_region(offset: int, regions: list[tuple[int, int]]) -> bool:
-    """Check if a byte offset falls within any of the given regions."""
-    for start, end in regions:
-        if start <= offset < end:
-            return True
-    return False
+_is_in_region = is_in_region
 
 
 def _check_api_in_gil_released(func: dict, source_bytes: bytes) -> list[dict]:
@@ -382,6 +387,7 @@ def main() -> None:
         json.dump(result, sys.stdout, indent=2)
         sys.stdout.write("\n")
     except Exception as e:
+        print(traceback.format_exc(), file=sys.stderr)
         json.dump({"error": str(e), "type": type(e).__name__}, sys.stdout, indent=2)
         sys.stdout.write("\n")
         sys.exit(1)

--- a/tests/test_scan_atomic_candidates.py
+++ b/tests/test_scan_atomic_candidates.py
@@ -187,15 +187,14 @@ class TestScanAtomicCandidates(unittest.TestCase):
             ]
             self.assertEqual(len(protect), 0)
 
-    def test_init_only_lower_severity(self):
-        """Init-only variable gets SAFE classification."""
+    def test_init_only_not_flagged(self):
+        """Init-only primitive variable is not flagged as atomic candidate."""
         with TempExtension({"init.c": INIT_ONLY_VAR}) as root:
             result = ac.analyze(str(root))
             findings = [
                 f for f in result["findings"] if f["variable"] == "module_version"
             ]
-            if findings:
-                self.assertEqual(findings[0]["classification"], "SAFE")
+            self.assertEqual(len(findings), 0)
 
     def test_const_not_flagged(self):
         """Const variable is not flagged."""
@@ -220,8 +219,10 @@ class TestScanAtomicCandidates(unittest.TestCase):
             self.assertIn("project_root", result)
             self.assertIn("scan_root", result)
             self.assertIn("files_analyzed", result)
+            self.assertIn("functions_analyzed", result)
             self.assertIn("findings", result)
             self.assertIn("summary", result)
+            self.assertIn("skipped_files", result)
 
 
 if __name__ == "__main__":

--- a/tests/test_scan_lock_discipline.py
+++ b/tests/test_scan_lock_discipline.py
@@ -287,8 +287,10 @@ class TestScanLockDiscipline(unittest.TestCase):
             self.assertIn("project_root", result)
             self.assertIn("scan_root", result)
             self.assertIn("files_analyzed", result)
+            self.assertIn("functions_analyzed", result)
             self.assertIn("findings", result)
             self.assertIn("summary", result)
+            self.assertIn("skipped_files", result)
 
 
 if __name__ == "__main__":

--- a/tests/test_scan_shared_state.py
+++ b/tests/test_scan_shared_state.py
@@ -245,8 +245,8 @@ class TestScanSharedState(unittest.TestCase):
             init_findings = [
                 f for f in result["findings"] if f["variable"] == "initialized"
             ]
-            if init_findings:
-                self.assertIn(init_findings[0]["severity"], ("LOW",))
+            self.assertTrue(len(init_findings) > 0, "Expected init-only findings")
+            self.assertIn(init_findings[0]["severity"], ("LOW",))
 
     def test_lock_protected_noted(self):
         """Lock-protected variables are noted in findings."""


### PR DESCRIPTION
## Summary
- Fix 4 critical silent data-loading failures where scanners silently produced zero findings when JSON data files failed to load — now warn to stderr
- Fix conditional test assertions that silently passed on empty findings (exposed a genuine test bug: `test_init_only_lower_severity` expected findings the scanner correctly suppresses)
- Extract 3 duplicated helpers (`is_thread_local`, `is_init_function`, `is_in_region`) from 4 scanners into `scan_common.py`
- Add traceback printing to all 7 `main()` functions, fix redundant decode, update plugin.json counts, add missing test assertions, document envelope variants in CLAUDE.md

## Test plan
- [x] `ruff format` + `ruff check` — all clean
- [x] `python -m unittest discover tests -v` — 81 tests pass
- [x] Net +127/-84 lines across 14 files

Closes #17

Generated with [Claude Code](https://claude.com/claude-code)