### PR TITLE
chore: bump plugin version to 0.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,8 +7,8 @@
     {
       "name": "ft-review-toolkit",
       "source": "./plugins/ft-review-toolkit",
-      "description": "Free-threading migration toolkit for CPython C extensions. Finds thread-safety bugs (data races, unprotected shared state, unsafe API usage, lock discipline issues), plans migrations to free-threaded Python (PEP 703), triages ThreadSanitizer reports, generates concurrent stress tests for TSan, and produces readiness assessments. 9 agents, 6 scripts, 3 commands. Tree-sitter-powered C/C++ parsing.",
-      "version": "0.2.0"
+      "description": "Free-threading migration toolkit for CPython C extensions. Finds thread-safety bugs (data races, unprotected shared state, unsafe API usage, lock discipline issues), plans migrations to free-threaded Python (PEP 703), triages ThreadSanitizer reports, generates concurrent stress tests for TSan, and produces readiness assessments. 10 agents, 7 scripts, 3 commands. Tree-sitter-powered C/C++ parsing.",
+      "version": "0.3.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-18
+
 ### Added
 - Project scaffolding and plugin structure
 - Vendored `tree_sitter_utils.py` and `scan_common.py` from cext-review-toolkit

--- a/plugins/ft-review-toolkit/.claude-plugin/plugin.json
+++ b/plugins/ft-review-toolkit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ft-review-toolkit",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Free-threading migration toolkit for CPython C extensions. Finds thread-safety bugs (data races, unprotected shared state, unsafe API usage, lock discipline issues), plans migrations to free-threaded Python (PEP 703), triages ThreadSanitizer reports, generates concurrent stress tests for TSan, and produces readiness assessments. 10 agents, 7 scripts, 3 commands. Tree-sitter-powered C/C++ parsing.",
   "author": {
     "name": "Danzin"


### PR DESCRIPTION
## Summary

- Promote `[Unreleased]` to `[0.3.0] - 2026-04-18` in `CHANGELOG.md` and open a fresh empty `[Unreleased]`.
- Bump `plugins/ft-review-toolkit/.claude-plugin/plugin.json` version 0.2.0 → 0.3.0.
- Bump `.claude-plugin/marketplace.json` version 0.2.0 → 0.3.0 and sync its description to the correct counts (10 agents, 7 scripts) that `plugin.json` already carries after `stw-safety-checker` + `scan_stw_safety.py` landed.

Captures work merged into `main` since `d85900f` (0.2.0): #16 (cext-review-toolkit enhancements), the STW safety work including Yifei's Py 3.14+ contract revision, #18 (code-review-toolkit findings), #20 (remaining findings), and #21 (cross-toolkit sync — ThreadPoolExecutor + `--workers`, pipe-deadlock fix, operational footer for the 7 script-backed agents, Phase 2b fix-completeness methodology).

SemVer minor: features added, bugfixes included, no breaking changes for existing agent/script callers.

## Test plan

- [x] `ruff check CHANGELOG.md plugins/ft-review-toolkit/.claude-plugin/plugin.json .claude-plugin/marketplace.json` — clean.
- [x] `python -m unittest discover tests` — 144 tests pass.
- [x] mypy skipped (this change only touches JSON + markdown).

Closes #22

Generated with [Claude Code](https://claude.com/claude-code)